### PR TITLE
Support powershell and other shells

### DIFF
--- a/src/helpers/os-detect.ts
+++ b/src/helpers/os-detect.ts
@@ -1,0 +1,19 @@
+import os from 'os';
+import path from 'path';
+
+export function detectShell() {
+  try {
+    // Detect if we're running on win32 and assume powershell
+    if (os.platform() === 'win32') {
+      return 'powershell';
+    }
+    // otherwise return current shell
+    return path.basename(os.userInfo().shell ?? 'bash');
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return {
+        message: `Shell detection failed unexpectedly: (${err.message})`,
+      };
+    }
+  }
+}


### PR DESCRIPTION
Regarding #4 

**Changes**
- support detecting current shell and adding prompt based on this
- removed references to "bash" and instead uses generic "script" and relies on additional prompt to guide the target terminal

**Notes**
There could be a downside to this if the user wants to write a prompt not to run for the current machine running the application but maybe it's a safe assumption?

I haven't tested this sufficiently on my end yet; if anybody with windows machines could confirm whether it works for them?

