### PR TITLE
Update docs to explain the 429 error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm update -g @builder.io/ai-shell
 
 Some users are reporting a 429 from OpenAI. This is due to incorrect billing setup or excessive quota usage. Please follow [this guide](https://help.openai.com/en/articles/6891831-error-code-429-you-exceeded-your-current-quota-please-check-your-plan-and-billing-details) to fix it.
 
-You can activate billing on [this link](https://platform.openai.com/account/billing/overview). Make sure to add a payment method if not under an active grant from OpenAI:
+You can activate billing at [this link](https://platform.openai.com/account/billing/overview). Make sure to add a payment method if not under an active grant from OpenAI.
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ If it's not the [latest version](https://github.com/BuilderIO/ai-shell/tags), ru
 npm update -g @builder.io/ai-shell
 ```
 
+## Common Issues
+
+##### 429
+
+Some users are reporting a 429 from OpenAI. This is due to incorrect billing setup or excessive quota usage. Please follow [this guide](https://help.openai.com/en/articles/6891831-error-code-429-you-exceeded-your-current-quota-please-check-your-plan-and-billing-details) to fix it.
+
+You can activate billing on [this link](https://platform.openai.com/account/billing/overview). Make sure to add a payment method if not under an active grant from OpenAI:
+
 ## Motivation
 
 I am not a bash wizard, and am dying for access to the copilot CLI, and got impatient.


### PR DESCRIPTION
At a first glance the 429 error has been confusing for some users. See issues #6, #13 and #18, all raise in the same time span.

This improves the documentation to support that error and give general indications on how to overcome it.