### PR TITLE
add silent option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ Then you will get an output like this, where you can choose to run the suggested
 │  ○ ❌ Cancel
 └
 ```
-
+you can disable and skip the explanation section by using the flag <b>-s</b> or <b>--silent</b>.
+or save the option as a preference using this command:
+```bash
+ai-shell config set SILENT_MODE=TRUE
+```
 ### Special characters
 
 Note that some shells handle certain characters like the `?` or `*` or things that look like file paths specially. If you are getting strange behaviors, you can wrap the prompt in quotes to avoid issues, like below:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,11 +14,17 @@ cli(
         description: 'Prompt to run',
         alias: 'p',
       },
+      silent: {
+        type: Boolean,
+        description: 'less verbose, skip printing the command explanation ',
+        alias: 's',
+      },
     },
     commands: [config],
   },
   (argv) => {
+    const silentMode = argv.flags.silent;
     const promptText = argv._.join(' ');
-    prompt({ usePrompt: promptText });
+    prompt({ usePrompt: promptText, silentMode });
   }
 );

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -34,6 +34,9 @@ const configParsers = {
 
     return model as TiktokenModel;
   },
+  SILENT_MODE(mode?: string) {
+    return String(mode).toLowerCase() === 'true';
+  }
 } as const;
 
 type ConfigKeys = keyof typeof configParsers;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -68,8 +68,10 @@ async function promptForRevision() {
   return (await group).prompt;
 }
 
-export async function prompt({ usePrompt }: { usePrompt?: string } = {}) {
-  const { OPENAI_KEY: key } = await getConfig();
+export async function prompt({ usePrompt, silentMode }: { usePrompt?: string, silentMode?: boolean } = {}) {
+  const { OPENAI_KEY: key, SILENT_MODE } = await getConfig();
+  const skipCommandExplanation = silentMode || SILENT_MODE;
+  
   if (!key) {
     throw new KnownError(
       'Please set your OpenAI API key via `ai-shell config set OPENAI_KEY=<your token>`'
@@ -92,17 +94,19 @@ export async function prompt({ usePrompt }: { usePrompt?: string } = {}) {
   const script = await readScript(process.stdout.write.bind(process.stdout));
   console.log('');
   console.log('');
-  console.log(dim('•'));
-  spin.start(`Getting explanation...`);
-  let info = await readInfo(process.stdout.write.bind(process.stdout));
-  if (!info) {
-    const { readExplanation } = await getExplanation({ script, key });
-    spin.stop(`Explanation:`);
-    console.log('');
-    await readExplanation(process.stdout.write.bind(process.stdout));
-    console.log('');
-    console.log('');
+  if(!skipCommandExplanation) {
     console.log(dim('•'));
+    spin.start(`Getting explanation...`);
+    let info = await readInfo(process.stdout.write.bind(process.stdout));
+    if (!info) {
+      const { readExplanation } = await getExplanation({ script, key });
+      spin.stop(`Explanation:`);
+      console.log('');
+      await readExplanation(process.stdout.write.bind(process.stdout));
+      console.log('');
+      console.log('');
+      console.log(dim('•'));
+    }
   }
 
   await runOrReviseFlow(script, key);


### PR DESCRIPTION
1.  allow users to use -s or --silent to skip the explanation section.
2.  save this optino to config file 

