### PR TITLE
feat: add custom openai api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@
    ai-shell config set OPENAI_KEY=<your token>
    ```
 
+   And you can custom OpenAI API endpoint to set  OPENAI_API_ENDPOINT （default: `https://api.openai.com/v1`）
+
+   ```sh
+   ai-shell config set OPENAI_API_ENDPOINT=<your proxy endpoint>
+   ```
+
    This will create a `.ai-shell` file in your home directory.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
    ai-shell config set OPENAI_KEY=<your token>
    ```
 
-   And you can custom OpenAI API endpoint to set  OPENAI_API_ENDPOINT （default: `https://api.openai.com/v1`）
+   And you can custom OpenAI API endpoint to set OPENAI_API_ENDPOINT （default: `https://api.openai.com/v1`）
 
    ```sh
    ai-shell config set OPENAI_API_ENDPOINT=<your proxy endpoint>
@@ -117,6 +117,7 @@ To get an interactive UI like below:
 ```bash
 ◆  Set config:
 │  ○ OpenAI Key
+│  ○ OpenAI API Endpoint
 │  ○ Silent Mode
 │  ● Model (gpt-3.5-turbo)
 │  ○ Cancel

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -117,6 +117,13 @@ export const showConfigUI = async () => {
             : '(not set)',
         },
         {
+          label: 'OpenAI API Endpoint',
+          value: 'OPENAI_API_ENDPOINT',
+          hint: hasOwn(config, 'OPENAI_API_ENDPOINT')
+            ? config.OPENAI_API_ENDPOINT
+            : '(not set)',
+        },
+        {
           label: 'Silent Mode',
           value: 'SILENT_MODE',
           hint: hasOwn(config, 'SILENT_MODE')
@@ -147,6 +154,12 @@ export const showConfigUI = async () => {
       });
       if (p.isCancel(key)) return;
       setConfigs([['OPENAI_KEY', key]]);
+    } else if (choice === 'OPENAI_API_ENDPOINT') {
+      const apiEndpoint = await p.text({
+        message: 'Enter your OpenAI API Endpoint',
+      });
+      if (p.isCancel(apiEndpoint)) return;
+      setConfigs([['OPENAI_API_ENDPOINT', apiEndpoint]]);
     } else if (choice === 'SILENT_MODE') {
       const silentMode = await p.confirm({
         message: 'Enable silent mode?',

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -39,6 +39,9 @@ const configParsers = {
   SILENT_MODE(mode?: string) {
     return String(mode).toLowerCase() === 'true';
   },
+  OPENAI_API_ENDPOINT(apiEndpoint?: string) {
+    return apiEndpoint || 'https://api.openai.com/v1';
+  },
 } as const;
 
 type ConfigKeys = keyof typeof configParsers;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -135,7 +135,11 @@ export async function prompt({
   await runOrReviseFlow(script, key, apiEndpoint);
 }
 
-async function runOrReviseFlow(script: string, key: string, apiEndpoint: string) {
+async function runOrReviseFlow(
+  script: string,
+  key: string,
+  apiEndpoint: string
+) {
   const nonEmptyScript = script.trim() !== '';
 
   const answer = await p.select({


### PR DESCRIPTION
If you can't access the OpenAI API directly (due to firewall or other issues), you can use it.

And you can custom OpenAI API endpoint to set OPENAI_API_ENDPOINT （default: https://api.openai.com/v1）

```sh
ai-shell config set OPENAI_API_ENDPOINT=<your proxy endpoint>
```