### PR TITLE
#37 #40 Remove the restriction that requires the Key to start with 'sk-.'

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -25,7 +25,6 @@ const configParsers = {
         `Please set your OpenAI API key via \`${commandName} config set OPENAI_KEY=<your token>\``
       );
     }
-    parseAssert('OPENAI_KEY', key.startsWith('sk-'), 'Must start with "sk-"');
 
     return key;
   },


### PR DESCRIPTION
=

If the proxy endpoint is Azure, the openai_key should not start with 'sk'.