### PR TITLE
Fixing last version in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.21
+## 0.1.22
 
 - Fix a crash on linux [#64](https://github.com/BuilderIO/ai-shell/issues/64)
 


### PR DESCRIPTION
The issue was fixed in #64. The version is correctly reflected on the package but not on CHANGELOG.md.