### PR TITLE
fix: handle "Invalid config property" log for "ai config get ..." cmd

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -39,6 +39,10 @@ export default command(
         for (const key of keyValues) {
           if (hasOwn(config, key)) {
             console.log(`${key}=${config[key as keyof typeof config]}`);
+          } else {
+            throw new KnownError(
+              `${i18n.t('Invalid config property')}: ${key}`
+            );
           }
         }
         return;


### PR DESCRIPTION
I noticed that when a user attempts to set an invalid property in the config, they receive an error response from the cli, however, when the user tries to `config get` non-existed property - there is silence, so I thought we could be consistent here