### PR TITLE
show help description for commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,11 +20,11 @@ cli(
       },
       silent: {
         type: Boolean,
-        description: 'less verbose, skip printing the command explanation ',
+        description: 'Less verbose, skip printing the command explanation ',
         alias: 's',
       },
     },
-    commands: [config, chat],
+    commands: [config, chat, update],
   },
   (argv) => {
     const silentMode = argv.flags.silent;

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -10,8 +10,10 @@ import i18n from '../helpers/i18n';
 export default command(
   {
     name: 'chat',
-    description:
-      'start a new chat session to send and receive messages, continue replying until the user chooses to exit.',
+    help: {
+      description:
+        'Start a new chat session to send and receive messages, continue replying until the user chooses to exit.',
+    },
   },
   async () => {
     const {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,7 +13,9 @@ export default command(
   {
     name: 'config',
     parameters: ['[mode]', '[key=value...]'],
-    description: 'Configure the CLI',
+    help: {
+      description: 'Configure the CLI',
+    },
   },
   (argv) => {
     (async () => {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -6,7 +6,9 @@ import i18n from '../helpers/i18n';
 export default command(
   {
     name: 'update',
-    description: 'Update AI Shell to the latest version',
+    help: {
+      description: 'Update AI Shell to the latest version',
+    },
   },
   async () => {
     console.log('');


### PR DESCRIPTION
fix:  The update command and the description of commands are not shown in the help menu 

![image](https://github.com/BuilderIO/ai-shell/assets/37481319/d1319151-8715-450b-b8f7-78e126ff17a1)
