### PR TITLE
read and use the configured model 

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -99,6 +99,7 @@ export async function prompt({
     OPENAI_KEY: key,
     SILENT_MODE,
     OPENAI_API_ENDPOINT: apiEndpoint,
+    MODEL: model,
   } = await getConfig();
   const skipCommandExplanation = silentMode || SILENT_MODE;
 
@@ -111,6 +112,7 @@ export async function prompt({
   const { readInfo, readScript } = await getScriptAndInfo({
     prompt: thePrompt,
     key,
+    model,
     apiEndpoint,
   });
   spin.stop(`${i18n.t('Your script')}:`);
@@ -137,12 +139,13 @@ export async function prompt({
     }
   }
 
-  await runOrReviseFlow(script, key, apiEndpoint, silentMode);
+  await runOrReviseFlow(script, key, model, apiEndpoint, silentMode);
 }
 
 async function runOrReviseFlow(
   script: string,
   key: string,
+  model: string,
   apiEndpoint: string,
   silentMode?: boolean
 ) {
@@ -181,7 +184,7 @@ async function runOrReviseFlow(
         label: '🔁 ' + i18n.t('Revise'),
         hint: i18n.t('Give feedback via prompt and get a new result'),
         value: async () => {
-          await revisionFlow(script, key, apiEndpoint, silentMode);
+          await revisionFlow(script, key, model, apiEndpoint, silentMode);
         },
       },
       {
@@ -211,6 +214,7 @@ async function runOrReviseFlow(
 async function revisionFlow(
   currentScript: string,
   key: string,
+  model: string,
   apiEndpoint: string,
   silentMode?: boolean
 ) {
@@ -221,6 +225,7 @@ async function revisionFlow(
     prompt: revision,
     code: currentScript,
     key,
+    model,
     apiEndpoint,
   });
   spin.stop(`${i18n.t(`Your new script`)}:`);
@@ -237,6 +242,7 @@ async function revisionFlow(
     const { readExplanation } = await getExplanation({
       script,
       key,
+      model,
       apiEndpoint,
     });
 
@@ -248,7 +254,7 @@ async function revisionFlow(
     console.log(dim('•'));
   }
 
-  await runOrReviseFlow(script, key, apiEndpoint, silentMode);
+  await runOrReviseFlow(script, key, model, apiEndpoint, silentMode);
 }
 
 export const parseAssert = (name: string, condition: any, message: string) => {


### PR DESCRIPTION
Currently, only the chat mode uses the specified model in the config file, meanwhile, the  prompt  always uses the default model ( __gpt-3.5-turbo__) 