### PR TITLE
Fixed empty response issue

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -94,5 +94,5 @@ async function getResponse({
 
   const iterableStream = streamToIterable(stream);
 
-  return { readResponse: readData(iterableStream, () => true) };
+  return { readResponse: readData(iterableStream) };
 }

--- a/src/helpers/completion.ts
+++ b/src/helpers/completion.ts
@@ -181,7 +181,11 @@ export async function getRevision({
   });
   const iterableStream = streamToIterable(stream);
   return {
-    readScript: readData(iterableStream),
+    readScript: readData(
+      iterableStream,
+      shellCodeStartRegex,
+      shellCodeEndRegex
+    ),
   };
 }
 

--- a/src/helpers/strip-regex-patterns.ts
+++ b/src/helpers/strip-regex-patterns.ts
@@ -1,9 +1,9 @@
 export const stripRegexPatterns = (
   inputString: string,
-  patternList: (RegExp | undefined)[]
+  patternList: (RegExp | string | undefined)[]
 ) =>
   patternList.reduce(
-    (currentString, pattern) =>
+    (currentString: string, pattern) =>
       pattern ? currentString.replaceAll(pattern, '') : currentString,
     inputString
   );

--- a/src/helpers/strip-regex-patterns.ts
+++ b/src/helpers/strip-regex-patterns.ts
@@ -1,0 +1,9 @@
+export const stripRegexPatterns = (
+  inputString: string,
+  patternList: (RegExp | undefined)[]
+) =>
+  patternList.reduce(
+    (currentString, pattern) =>
+      pattern ? currentString.replaceAll(pattern, '') : currentString,
+    inputString
+  );


### PR DESCRIPTION
Fixes Issue #94: Chat Gives Empty Response

**Root Cause**
The parser was expecting chunks to contain triple backticks (```) as a marker to start appending content. However, the chunks were being split into smaller pieces that only contained a pair of backticks (``) and a backtick followed by a newline character (`\n). This caused the parser to never encounter the expected triple backticks, resulting in empty responses.

<img width="833" alt="Screenshot 2023-09-21 at 03 41 52" src="https://github.com/BuilderIO/ai-shell/assets/8009079/97b279b5-b2d9-4068-a5a3-92675a3a3033">
<img width="833" alt="Screenshot 2023-09-21 at 03 44 13" src="https://github.com/BuilderIO/ai-shell/assets/8009079/54990c19-0622-40eb-a89c-622acb0036bd">
