### PR TITLE
Add support for user to select from currently available models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.0.8
+
 - Fix a bug causing completions to not display in some cases
 - Allow hitting "q" or "esc" to stop the streaming output
 

--- a/src/helpers/completion.ts
+++ b/src/helpers/completion.ts
@@ -1,4 +1,9 @@
-import { OpenAIApi, Configuration, ChatCompletionRequestMessage } from 'openai';
+import {
+  OpenAIApi,
+  Configuration,
+  ChatCompletionRequestMessage,
+  Model,
+} from 'openai';
 import dedent from 'dedent';
 import { IncomingMessage } from 'http';
 import { KnownError } from './error';
@@ -312,4 +317,14 @@ function getRevisionPrompt(prompt: string, code: string) {
 
     ${generationDetails}
   `;
+}
+
+export async function getModels(
+  key: string,
+  apiEndpoint: string
+): Promise<Model[]> {
+  const openAi = getOpenAi(key, apiEndpoint);
+  const response = await openAi.listModels();
+
+  return response.data.data.filter((model) => model.object === 'model');
 }

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -8,6 +8,8 @@ import { KnownError, handleCliError } from './error';
 import * as p from '@clack/prompts';
 import { red } from 'kolorist';
 import i18n from './i18n';
+import { getModels } from './completion';
+import { Model } from 'openai';
 
 const { hasOwnProperty } = Object.prototype;
 export const hasOwn = (object: unknown, key: PropertyKey) =>
@@ -186,9 +188,16 @@ export const showConfigUI = async () => {
       if (p.isCancel(silentMode)) return;
       await setConfigs([['SILENT_MODE', silentMode ? 'true' : 'false']]);
     } else if (choice === 'MODEL') {
-      const model = await p.text({
-        message: i18n.t('Enter the model you want to use'),
-      });
+      const { OPENAI_KEY: key, OPENAI_API_ENDPOINT: apiEndpoint } =
+        await getConfig();
+      const models = await getModels(key, apiEndpoint);
+      const model = (await p.select({
+        message: 'Pick a model.',
+        options: models.map((m: Model) => {
+          return { value: m.id, label: m.id };
+        }),
+      })) as string;
+
       if (p.isCancel(model)) return;
       await setConfigs([['MODEL', model]]);
     } else if (choice === 'LANGUAGE') {


### PR DESCRIPTION
#### Background
In the current configuration, selecting a model requires the user to manually input the model name. This approach can lead to several issues, such as:
- Users might not know which models are available.
- There is a potential for input errors.

#### Changes
To improve the user experience, I have added a feature that allows users to select from the currently available models instead of manually entering the name. This will reduce errors and make the configuration process more intuitive.

#### Impact
- Enhanced user experience by reducing errors from manual input.
- Made the configuration process more user-friendly and flexible.
![image](https://github.com/BuilderIO/ai-shell/assets/22143266/dc4e638c-4fde-4f5c-9a3f-67beeff89385)

Thank you for taking the time to review this PR. If you have any questions or suggestions, please feel free to reach out to me.

---

I hope this helps! If you need any further adjustments or have additional questions, let me know.