### PR TITLE
fix: ensure getExplanation uses the settled MODEL

### DIFF
--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -134,6 +134,7 @@ export async function prompt({
       const { readExplanation } = await getExplanation({
         script,
         key,
+        model,
         apiEndpoint,
       });
       spin.stop(`${i18n.t('Explanation')}:`);


### PR DESCRIPTION
The `getExplanation` method is currently defaulting to the standard model instead of the custom model specified in the initial step.

This PR corrects the issue by ensuring that the `getExplanation` method correctly uses the custom model, maintaining the intended functionality.

> in the screnshot, I am using custom model, but it trying the default model during the second step
<img width="598" alt="image" src="https://github.com/user-attachments/assets/b408c412-d884-4f28-8b2d-fdf135786877">
