### PR TITLE
respect $HISTFILE

### DIFF
--- a/src/helpers/shell-history.ts
+++ b/src/helpers/shell-history.ts
@@ -4,6 +4,10 @@ import path from 'path';
 
 // Function to get the history file based on the shell
 function getHistoryFile(): string | null {
+  if (process.env.HISTFILE) {
+    return process.env.HISTFILE;
+  }
+
   const shell = process.env.SHELL || '';
   const homeDir = os.homedir();
 


### PR DESCRIPTION
When a history file is not in the default location, it is often available via $HISTFILE.  This patch will respect $HISTFILE and avoid writing to the default location when that file is not in use.