### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
 
 <br>
 
+<p align="center">
+   <!-- Keep these links. Translations will automatically update with the README. -->
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=de">Deutsch</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=es">Español</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=fr">français</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=ja">日本語</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=ko">한국어</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=pt">Português</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=ru">Русский</a> | 
+   <a href="https://www.readme-i18n.com/BuilderIO/ai-shell?lang=zh">中文</a>
+</p>
+
 # AI Shell
 
 ## Setup


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

This update improves accessibility and project understanding for non-English speakers around the world.

The updated links can be previewed in my forked repository: https://github.com/dowithless/ai-shell/tree/patch-1